### PR TITLE
Added 'alias' and 'domain' attributes to XML for the Email field

### DIFF
--- a/fields/field.memberemail.php
+++ b/fields/field.memberemail.php
@@ -221,9 +221,13 @@
 		public function appendFormattedElement(&$wrapper, $data, $encode=false){
 			if(!isset($data['value'])) return;
 
+			$mail = explode('@', General::sanitize($data['value']));
+
 			$wrapper->appendChild(
 				new XMLElement($this->get('element_name'), General::sanitize($data['value']), array(
-					'hash' => md5($data['value'])
+					'hash' => md5($data['value']),
+					'alias' => $mail[0],
+					'domain' => $mail[1]
 				))
 			);
 		}


### PR DESCRIPTION
I had a need to retrieve only the email domain from the email field, so I made a change to make that simple.  It just does a simple explode on the email value and assign appropriately.  It was only an addition of three lines of code.
