### PR TITLE
fix bug causing sql syntax error

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -96,9 +96,8 @@
 		public function __construct() {
 			if(!extension_Members::$initialised) {
 				// Find all possible member sections
-				$config_sections = explode(',',extension_Members::getSetting('section'));
+                $config_sections = preg_split('~,~',extension_Members::getSetting('section'), -1, PREG_SPLIT_NO_EMPTY);
 				extension_Members::initialiseMemberSections($config_sections);
-
 				if(class_exists('Symphony') && Symphony::Engine() instanceof Frontend) {
 					/**
 					 * This delegate fires as soon as possible to allow other extensions


### PR DESCRIPTION
On fresh installations `explode` wouldn't result in an array containing an empty string which causes a SQL syntax error. Use `preg_split` instead. 
