### PR TITLE
Added assumed role to Role Field XML

### DIFF
--- a/fields/field.memberrole.php
+++ b/fields/field.memberrole.php
@@ -267,6 +267,7 @@
 
 			$element = new XMLElement($this->get('element_name'), null, array(
 				'id' => $role->get('id'),
+				'assumed-id' => $data["role_id"],
 				'mode' => ($mode == "permissions") ? $mode : 'normal'
 			));
 			$element->appendChild(


### PR DESCRIPTION
Added an attribute to the role XML that outputs the assumed role after
activation, not just the current role… usually public if not activated.