### PR TITLE
Removed unnecessary SQL queries when checking activation

### DIFF
--- a/lib/member.symphony.php
+++ b/lib/member.symphony.php
@@ -89,7 +89,7 @@
 
 			// Check that if there's activiation, that this Member is activated.
 			if(!is_null($this->section->getFieldHandle('activation'))) {
-				$entry = EntryManager::fetch($member_id);
+				$entry = EntryManager::fetch($member_id, NULL, NULL, NULL, NULL, NULL, false, true, array($this->section->getFieldHandle('activation')));
 
 				$isActivated = $entry[0]->getData($this->section->getField('activation')->get('id'), true)->activated == "yes";
 


### PR DESCRIPTION
At the moment the fetch function is calling the full entry object, building all field data with it. On member sections with a large number of fields retrieving the data for all of the fields takes time, and seems unnecessary for this check.
