### PR TITLE
allow users to login when no password field is set

### DIFF
--- a/lib/member.symphony.php
+++ b/lib/member.symphony.php
@@ -245,8 +245,10 @@
 						$this->cookie->set('email', $data['email']);
 					}
 
-					$this->cookie->set('password', $this->getMember()->getData($this->section->getField('authentication')->get('id'), true)->password);
-
+					if (isset($credentials[$this->section->getFieldHandle('authentication')])){
+						$this->cookie->set('password', $this->getMember()->getData($this->section->getField('authentication')->get('id'), true)->password);
+					}
+					
 					self::$isLoggedIn = true;
 
 				} catch(Exception $ex){


### PR DESCRIPTION
There are two changes; the most important is when there is no password field set; members was crashing when trying to set the password cookie. Just made a check to confirm that there is a password field.

Secondly I would like to initialise the Members extension from custom backend content pages. For example I want to login someone when conducting a payment (temporary redirect to a /symphony/extension/content page) however there is no way to get any status of the current user at that point. Allowing extensions to set a 'context' when the frontend user should be initialised is a nice thing to have. If there are other suggestions I'm open. I'm not really keen on using an event tied to a frontend page as that would have to be set manually every time I need to use the extension. 
