### PR TITLE
Minor fixes

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -139,6 +139,9 @@
 					else if(isset($members_section_id) && in_array((int)$members_section_id, $config_sections)) {
 						$this->setMembersSection($members_section_id);
 					}
+					else {
+						$this->setMembersSection($config_sections[0]);
+					}
 				}
 
 				extension_Members::$initialised = true;

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -952,7 +952,8 @@
 					 *  The username of the Member who attempted to login.
 					 */
 					Symphony::ExtensionManager()->notifyMembers('MembersLoginFailure', '/frontend/', array(
-						'username' => Symphony::Database()->cleanValue($_POST['fields'][extension_Members::getFieldHandle('identity')])
+						'username' => Symphony::Database()->cleanValue($_POST['fields'][extension_Members::getFieldHandle('identity')]),
+						'email' => Symphony::Database()->cleanValue($_POST['fields'][extension_Members::getFieldHandle('email')])
 					));
 				}
 			}


### PR DESCRIPTION
This pull request fixes two minor issues:

1. A user can either be logged in with his username or with his email address. Both should be passed to the login failure delegate.
2. When using multiple section, Members should always fallback to one of the configured sections.