### PR TITLE
Restore tags selection

### DIFF
--- a/fields/field.memberactivation.php
+++ b/fields/field.memberactivation.php
@@ -208,7 +208,7 @@
 				"fields[{$this->get('sortorder')}][code_expiry]", $this->get('code_expiry')
 			));
 
-			$ul = new XMLElement('ul', NULL, array('class' => 'tags singular'));
+			$ul = new XMLElement('ul', NULL, array('class' => 'tags singular', 'data-interactive' => 'data-interactive'));
 			$tags = fieldMemberActivation::findCodeExpiry();
 			foreach($tags as $name => $time) {
 				$ul->appendChild(new XMLElement('li', $name, array('class' => $time)));

--- a/fields/field.memberactivation.php
+++ b/fields/field.memberactivation.php
@@ -208,7 +208,7 @@
 				"fields[{$this->get('sortorder')}][code_expiry]", $this->get('code_expiry')
 			));
 
-			$ul = new XMLElement('ul', NULL, array('class' => 'tags singular', 'data-interactive' => 'data-interactive'));
+			$ul = new XMLElement('ul', null, array('class' => 'tags singular', 'data-interactive' => 'data-interactive'));
 			$tags = fieldMemberActivation::findCodeExpiry();
 			foreach($tags as $name => $time) {
 				$ul->appendChild(new XMLElement('li', $name, array('class' => $time)));

--- a/fields/field.memberpassword.php
+++ b/fields/field.memberpassword.php
@@ -350,7 +350,7 @@
 				"fields[{$this->get('sortorder')}][code_expiry]", $this->get('code_expiry')
 			));
 
-			$ul = new XMLElement('ul', NULL, array('class' => 'tags singular'));
+			$ul = new XMLElement('ul', null, array('class' => 'tags singular', 'data-interactive' => 'data-interactive'));
 			$tags = fieldMemberPassword::findCodeExpiry();
 			foreach($tags as $name => $time) {
 				$ul->appendChild(new XMLElement('li', $name, array('class' => $time)));


### PR DESCRIPTION
In 2.7.0, tags are broken because they need the `data-interactive`
attribute. This commit simply adds it.

Fixes #279