### PR TITLE
Remove bottom margin for the password note

### DIFF
--- a/assets/members.publish.css
+++ b/assets/members.publish.css
@@ -7,3 +7,7 @@
 	height: auto;
 	background: rgba(255, 255, 255, 0.8);
 }
+
+.field-memberpassword .column {
+	margin-bottom: 0;
+}


### PR DESCRIPTION
By default, columns have a bottom margin. In this case, we need the note
to be with the fields. Without this change, the note is perfectly
between the two inputs and the field below, which makes it hard to know
the field to which is belongs.