### PR TITLE
Show a friendlier message on init error

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -139,7 +139,7 @@
 					else if(isset($members_section_id) && in_array((int)$members_section_id, $config_sections)) {
 						$this->setMembersSection($members_section_id);
 					}
-					else if (isset($config_sections[0]) && !empty($config_sections[0])) {
+					else if (!empty($config_sections[0])) {
 						$this->setMembersSection($config_sections[0]);
 					}
 					else {

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -139,8 +139,11 @@
 					else if(isset($members_section_id) && in_array((int)$members_section_id, $config_sections)) {
 						$this->setMembersSection($members_section_id);
 					}
-					else {
+					else if (isset($config_sections[0]) && !empty($config_sections[0])) {
 						$this->setMembersSection($config_sections[0]);
+					}
+					else {
+						throw new Exception(__('No member section found! Please check your configuration.'));
 					}
 				}
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -143,7 +143,7 @@
 						$this->setMembersSection($config_sections[0]);
 					}
 					else {
-						throw new Exception(__('No member section found! Please check your configuration.'));
+						throw new Exception(__('No Members section found! Please check your configuration.'));
 					}
 				}
 


### PR DESCRIPTION
When creating the member extension object in the frontend it needs to
know which section it needs to use as the member info source.

Right now, if the configured value is wrong, you get a weird message
about PHP type checking.

This commit adds a friendlier message when the configuration is not
valid.