### PR TITLE
 Replace extract() with proper check 

### DIFF
--- a/fields/field.memberemail.php
+++ b/fields/field.memberemail.php
@@ -56,10 +56,10 @@
 	-------------------------------------------------------------------------*/
 
 		public function fetchMemberIDBy($needle, $member_id = null) {
-			if(is_array($needle)) {
-				extract($needle);
-			}
-			else {
+			$email = null;
+			if (is_array($needle) && !empty($needle['email'])) {
+				$emaill = $needle['email'];
+			} else {
 				$email = $needle;
 			}
 

--- a/fields/field.memberpassword.php
+++ b/fields/field.memberpassword.php
@@ -158,7 +158,7 @@
 			}
 
 			// Check that if the password has been reset that it is still valid
-			if($valid && $data['reset'] == 'yes') {
+			if($valid && !empty($data['reset']) && $data['reset'] == 'yes') {
 				$valid_id = Symphony::Database()->fetchVar('entry_id', 0, sprintf("
 						SELECT `entry_id`
 						FROM `tbl_entries_data_%d`

--- a/fields/field.memberpassword.php
+++ b/fields/field.memberpassword.php
@@ -97,12 +97,9 @@
 		public function fetchMemberIDBy($needle, $member_id = null, $isHashed = false) {
 			$valid = true;
 			$password = null;
-			if(is_array($needle)) {
-				if (!empty($needle['password'])) {
-					$password = $needle['password'];
-				}
-			}
-			else {
+			if (is_array($needle) && !empty($needle['password'])) {
+				$password = $needle['password'];
+			} else {
 				$password = $needle;
 			}
 

--- a/fields/field.memberpassword.php
+++ b/fields/field.memberpassword.php
@@ -96,8 +96,11 @@
 		 */
 		public function fetchMemberIDBy($needle, $member_id = null, $isHashed = false) {
 			$valid = true;
+			$password = null;
 			if(is_array($needle)) {
-				extract($needle);
+				if (!empty($needle['password'])) {
+					$password = $needle['password'];
+				}
 			}
 			else {
 				$password = $needle;

--- a/fields/field.memberpassword.php
+++ b/fields/field.memberpassword.php
@@ -166,7 +166,9 @@
 						AND DATE_FORMAT(expires, '%%Y-%%m-%%d %%H:%%i:%%s') > '%s'
 						LIMIT 1
 					",
-					$this->get('id'), $data['entry_id'], DateTimeObj::get('Y-m-d H:i:s', strtotime('now - '. $this->get('code_expiry')))
+					$this->get('id'),
+					$data['entry_id'],
+					DateTimeObj::get('Y-m-d H:i:s', strtotime('now - '. $this->get('code_expiry')))
 				));
 
 				// If we didn't get an entry_id back, then it's because it was expired

--- a/fields/field.memberusername.php
+++ b/fields/field.memberusername.php
@@ -64,10 +64,10 @@
 		 * @return Entry
 		 */
 		public function fetchMemberIDBy($needle, $member_id = null) {
-			if(is_array($needle)) {
-				extract($needle);
-			}
-			else {
+			$username = null;
+			if (is_array($needle) && !empty($needle['username'])) {
+				$username = $needle['username'];
+			} else {
 				$username = $needle;
 			}
 

--- a/lib/member.symphony.php
+++ b/lib/member.symphony.php
@@ -20,10 +20,10 @@
 		 * @return Field
 		 */
 		public function setIdentityField(array $credentials, $simplified = true) {
-			if($simplified) {
-				extract($credentials);
-			}
-			else {
+			if ($simplified) {
+				$username = empty($credentials['username']) ? null : $credentials['username'];
+				$email = empty($credentials['email']) ? null : $credentials['email'];
+			} else {
 				// Map POST data to simple terms
 				if(isset($credentials[$this->section->getFieldHandle('identity')])) {
 					$username = $credentials[$this->section->getFieldHandle('identity')];


### PR DESCRIPTION
extract may lead to overwriting other variable, which can lead to
disaster when the function is called over used supplied data.

Fixes #252