### PR TITLE
Fix filter url

### DIFF
--- a/content/content.roles.php
+++ b/content/content.roles.php
@@ -86,7 +86,7 @@
 
 							$columns[] = Widget::TableData(Widget::Anchor(
 								"$member_count",
-								SYMPHONY_URL . '/publish/' . $section->get('handle') . '/?filter=' . $roleField->get('element_name') . ':' . $role->get('id')
+								SYMPHONY_URL . '/publish/' . $section->get('handle') . '/?filter[' . $roleField->get('element_name') . ']=' . $role->get('id')
 							));
 						}
 


### PR DESCRIPTION
filter:value is the old 2.0 syntax and oddly, this never got patched.

Fixes #280