### PR TITLE
Fix Role for same request as login

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -933,6 +933,8 @@
 					));
 
 					if(isset($_POST['redirect'])) redirect($_POST['redirect']);
+
+					$isLoggedIn = true;
 				}
 				else {
 					self::$_failed_login_attempt = true;


### PR DESCRIPTION
Scenario: show a login form on 403 requests (as a 403 page) - users log in. User role is still set as public so user still sees the 403 login page. On hard-reload the correct page with user logged in shows.

Fix: ensure that `$isLoggedIn` is set to true on successful login, role set correctly and behaves as expected.