### PR TITLE
Cast to integer consequently

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -527,7 +527,7 @@
 
 			if(in_array((int)$section_id, $config_sections)) {
 				extension_Members::$members_section = (int)$section_id;
-				$this->Member->setMemberSectionID(extension_Members::$member_sections[$section_id]);
+				$this->Member->setMemberSectionID(extension_Members::$member_sections[(int)$section_id]);
 
 				return true;
 			}


### PR DESCRIPTION
The section ID is casted to integer in the IF-block and in the line before, so missing it here is error-prone.