### PR TITLE
Do not throw exception when setting the ID fails

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -531,9 +531,6 @@
 
 				return true;
 			}
-			else {
-				throw new Exception(sprintf('Setting the active Members section to %d failed.', $section_id));
-			}
 
 			return false;
 		}


### PR DESCRIPTION
The function returns false anyway; failing more silently is preferrable.

Fixes #310