### PR TITLE
Prevent anyone but developer seeing member roles

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -159,7 +159,8 @@
 				array(
 					'location' 	=> __('System'),
 					'name' 		=> __('Member Roles'),
-					'link' 		=> '/roles/'
+					'link' 		=> '/roles/',
+					'limit' => 'developer'
 				)
 			);
 		}


### PR DESCRIPTION
It seems odd to me that all editors can edit member roles as they could break the site with this access.