### PR TITLE
Login should not get hash from memory if hash is supplied

### DIFF
--- a/lib/member.symphony.php
+++ b/lib/member.symphony.php
@@ -245,7 +245,8 @@
 						$this->cookie->set('email', $data['email']);
 					}
 
-					$this->cookie->set('password', $this->getMember()->getData($this->section->getField('authentication')->get('id'), true)->password);
+					$hashedPassword = $isHashed ? $data['password'] : $this->getMember()->getData($this->section->getField('authentication')->get('id'), true)->password;
+					$this->cookie->set('password', $hashedPassword );
 
 					self::$isLoggedIn = true;
 


### PR DESCRIPTION
Use-case is creating a Login-As function; supplying both user email and hash. The current function gets the password hash from memory (not fresh from database) hence links up the wrong username/password.

We are using this for symphony admins to be able to access/provide support to clients by "switching" frontend accounts.